### PR TITLE
Fix #417: add license folder

### DIFF
--- a/docs/2_3_fmu_distribution.adoc
+++ b/docs/2_3_fmu_distribution.adoc
@@ -22,8 +22,11 @@ This ZIP file has the following structure:
 modelDescription.xml      // Description of FMU (required file)
 model.png                 // Optional image file of FMU icon
 documentation             // Optional directory containing the FMU documentation
-index.html                // Entry point of the documentation
-<other documentation files>
+    index.html            // Entry point of the documentation
+    <other documentation files>
+    licenses                    // Optional directory for licenses
+        license.{txt,html}      // Entry point for license information
+        <license files>         // For example BSD licenses
 sources                   // Optional directory containing all C sources
    // all needed C sources and C header files to compile and link the FMU
    // with exception of: fmi2TypesPlatform.h , fmi2FunctionTypes.h and fmi2Functions.h
@@ -49,7 +52,7 @@ binaries                     // Optional directory containing the binaries win32
   linux64    // Optional binaries for 64-bit Linux
      ...
   < If an FMU is run through one of its binaries all items in that binary folder is recommended to be unpacked at the same location as the binary < modelIdentifier >.* is unpacked.
-   If not itâ€™s likely that, if the FMU has dependencies on those items, it will not be able to find them and run >
+   If not it’s likely that, if the FMU has dependencies on those items, it will not be able to find them and run >
 resources    // Optional resources needed by the FMU
    < data in FMU specific files which will be read during initialization;
      also more folders can be added under resources (tool/model specific).
@@ -130,6 +133,13 @@ This documentation should be stored in the `documentation` directory,
 possibly with a link to the template makefile (stored in the `sources` directory).
 _[As template makefile, CMake (http://www.cmake.org), a cross- platform,
 open-source build system might be used.]_ +
+The sub-directory `licenses` can be used to bundle all license files.
+_[It is strongly recommended to include all license and copyright related
+information in the licenses folder of an FMU (especially but not only
+for contained open source software) – the license.{html,txt} file can serve
+as an entry point for describing the contained licenses. This will help the users
+to comply with license conditions when passing source or binary code
+contained in an an FMU to other persons or organizations.]_
 In directory `resources`,
 additional data can be provided in FMU specific formats,
 typically for tables and maps used in the FMU.


### PR DESCRIPTION
This adds a license folder inside the documentation folder, and an entry point file that describes the licenses.